### PR TITLE
Fix broken resource url for tika-app.1.16.jar

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -40,7 +40,7 @@ build:
 hooks:
     build: |
       mkdir -p /app/srv/bin
-      cd /app/srv/bin && curl -OL http://download.nextag.com/apache/tika/tika-app-1.16.jar
+      cd /app/srv/bin && curl -OL http://archive.apache.org/dist/tika/tika-app-1.16.jar
     # The deploy hook runs after your application has been deployed and started.
     deploy: |
       cd web


### PR DESCRIPTION
The old resource is no longer available for download.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/thinktandem/platform-tika/1)
<!-- Reviewable:end -->
